### PR TITLE
help2man is now required for crosstool-NG

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,11 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     echo "Installing esp-open-sdk and micropython dependencies..."
     sudo apt-get update
-    sudo apt-get install -y build-essential git make unrar-free unzip autoconf automake libtool gcc g++ gperf flex bison texinfo gawk ncurses-dev libexpat-dev python sed libreadline-dev libffi-dev pkg-config
+    sudo apt-get install -y build-essential git make unrar-free unzip \
+                            autoconf automake libtool gcc g++ gperf \
+                            flex bison texinfo gawk ncurses-dev libexpat-dev \
+                            python sed libreadline-dev libffi-dev pkg-config \
+                            help2man
     echo "Installing esp-open-sdk and micropython source..."
     git clone --recursive https://github.com/pfalcon/esp-open-sdk.git
     git clone https://github.com/micropython/micropython.git

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure(2) do |config|
                             autoconf automake libtool gcc g++ gperf \
                             flex bison texinfo gawk ncurses-dev libexpat-dev \
                             python sed libreadline-dev libffi-dev pkg-config \
-                            help2man
+                            help2man python-dev
     echo "Installing esp-open-sdk and micropython source..."
     git clone --recursive https://github.com/pfalcon/esp-open-sdk.git
     git clone https://github.com/micropython/micropython.git


### PR DESCRIPTION
This commit fixes this issue during esp-open-sdk build:

  configure: error: missing required tool: help2man
  make[1]: **\* [_ct-ng] Error 1
