### PR TITLE
Automate esp-open-sdk and micropython library setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,18 @@ compiling the tools:
 
 This will set up your development environment and will take about 30 minutes to
 an hour or more depending on the speed of your machine. This is due to the
-process of cloning and compiling two git repositories:
+process of cloning and compiling three git repositories:
 
 *   [esp-open-sdk](https://github.com/pfalcon/esp-open-sdk) - This is an SDK to
     compile code for the ESP8266's processor.
 
+*   [esp-idf](https://github.com/espressif/esp-idf) - The official Espressif IoT
+    development framework.
+
 *   [micropython](https://github.com/micropython/micropython) - This is the MicroPython
     SDK which allows running embedded Python code on an ESP8266.
 
-After the virtual machine is brought up and provisioned use the following
+After the virtual machine is brought up and provisioned, use the following
 command to enter an SSH session on it:
 
     vagrant ssh
@@ -62,16 +65,9 @@ is the default configuration value).  If you change the Vagrantfile you will
 need to stop and restart the VM (see the Stopping & Starting the VM section
 further below).
 
-## MicroPython Firmware Compilation
+## MicroPython Firmware
 
-After the ESP open SDK has been compiled and added to the path, execute the
-following commands to start compiling MicroPython (the compilation is quick and
-only takes a few minutes depending on the speed of your machine):
-
-    cd ~/micropython/esp8266
-    make
-
-After the firmware compilation finishes the output will be the file ./build/firmware-combined.bin.
+After the development environment finishes, a file should have been produced ./build/firmware-combined.bin.
 This file should be flashed to the ESP8266 using any convenient flashing tool
 (see Flashing ESP8266 Firmware below).  You can copy the firmware-combined.bin file
 to Vagrant's shared directory so it is accessible from your main computer and

--- a/README.md
+++ b/README.md
@@ -25,13 +25,9 @@ compiling the tools:
 
     vagrant up
 
-After the virtual machine is brought up and provisioned use the following
-command to enter an SSH session on it:
-
-    vagrant ssh
-
-Once inside the virtual machine you will see two git repositories that have
-already been cloned:
+This will set up your development environment and will take about 30 minutes to
+an hour or more depending on the speed of your machine. This is due to the
+process of cloning and compiling two git repositories:
 
 *   [esp-open-sdk](https://github.com/pfalcon/esp-open-sdk) - This is an SDK to
     compile code for the ESP8266's processor.
@@ -39,22 +35,21 @@ already been cloned:
 *   [micropython](https://github.com/micropython/micropython) - This is the MicroPython
     SDK which allows running embedded Python code on an ESP8266.
 
-## ESP Open SDK Compilation
+After the virtual machine is brought up and provisioned use the following
+command to enter an SSH session on it:
 
-You will want to first compile the ESP open SDK by executing (note that the
-compilation will take about 30 minutes to an hour or more depending on the speed
-of your machine):
+    vagrant ssh
 
-    cd esp-open-sdk
-    make STANDALONE=y
+Once inside the virtual machine you will see the two git repositories that have
+already been cloned.
 
-Note that if the compilation fails with an error like:
+Note that if the setup fails with an error like:
 
     [ERROR]    collect2: error: ld terminated with signal 9 [Killed]
     [ERROR]    make[4]: *** [cc1] Error 1
     [ERROR]    make[3]: *** [all-gcc] Error 2
 
-This means the virtual machine ran out of memory during the last stages of the
+It means that the virtual machine ran out of memory during the last stages of the
 compilation process.  You can resolve this by bumping up the memory available to
 the VM by changing this line in the Vagrantfile
 
@@ -67,20 +62,7 @@ is the default configuration value).  If you change the Vagrantfile you will
 need to stop and restart the VM (see the Stopping & Starting the VM section
 further below).
 
-Once the ESP open SDK compilation has finished you need to extend the path
-environment variable so the tools are accessible to MicroPython and other build
-scripts.  You can do this by changing the .profile file so that on every login
-to the virtual machine it extends the path to includes these tools.  Do this by
-executing:
-
-    echo "PATH=$(pwd)/xtensa-lx106-elf/bin:\$PATH" >> ~/.profile
-
-Finally exit and re-enter the VM to make this path change available by running:
-
-    exit
-    vagrant ssh
-
-## MicroPython Compilation
+## MicroPython Firmware Compilation
 
 After the ESP open SDK has been compiled and added to the path, execute the
 following commands to start compiling MicroPython (the compilation is quick and

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,12 +30,18 @@ Vagrant.configure(2) do |config|
     tar xvfz xtensa-esp32-elf-linux64-1.22.0-61-gab8375a-5.2.0.tar.gz
     echo "PATH=/home/vagrant/xtensa-esp32-elf/bin:\$PATH" >> ~/.profile
     echo "Installing esp-open-sdk, Espressif ESP-IDF, and micropython source..."
+
     git clone --recursive https://github.com/pfalcon/esp-open-sdk.git
-    git clone --recursive https://github.com/espressif/esp-idf.git
     cd esp-open-sdk
     make STANDALONE=y
     echo "PATH=$(pwd)/xtensa-lx106-elf/bin:\$PATH" >> ~/.profile
     source ~/.profile
+
+    cd ..
+    git clone --recursive https://github.com/espressif/esp-idf.git
+    cd esp-idf
+    make all
+
     cd ..
     git clone --recursive https://github.com/micropython/micropython.git
     cd micropython

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,15 @@ Vagrant.configure(2) do |config|
     echo "Installing esp-open-sdk, Espressif ESP-IDF, and micropython source..."
     git clone --recursive https://github.com/pfalcon/esp-open-sdk.git
     git clone --recursive https://github.com/espressif/esp-idf.git
-    git clone https://github.com/micropython/micropython.git
+    cd esp-open-sdk
+    make STANDALONE=y
+    echo "PATH=$(pwd)/xtensa-lx106-elf/bin:\$PATH" >> ~/.profile
+    source ~/.profile
+    cd ..
+    git clone --recursive https://github.com/micropython/micropython.git
+    cd micropython
+    make -C mpy-cross
+    make -C esp8266 axtls
     echo "Finished provisioning, now run 'vagrant ssh' to enter the virtual machine."
   SHELL
 


### PR DESCRIPTION
As the [README of micropython/esp8266](https://github.com/micropython/micropython/blob/master/esp8266/README.md) describes, you now have to build both the micropython cross-compiler and the axtls library before being able to compile any esp8266 firmware.

I also see no reason not to build the esp-open-sdk when initializing the vagrant box.
Therefor all of this should, in my opinion, be automated by the vagrant provisioning script as these changes do.
